### PR TITLE
chore: ignore build user and whitespace in test

### DIFF
--- a/test/diff-test-runner
+++ b/test/diff-test-runner
@@ -8,7 +8,7 @@ actual_file=$1
 golden_file=$2
 
 # NB: diff fails when there's a difference to report.
-diff_output="$(diff ${golden_file} ${actual_file})" || :
+diff_output="$(diff -w ${golden_file} ${actual_file})" || :
 if [ -n "${diff_output}" ]; then
   echo "FAIL: Actual output differs from expected golden content:"
   echo "${diff_output}"

--- a/test/testdata/stamp/BUILD.bazel
+++ b/test/testdata/stamp/BUILD.bazel
@@ -10,7 +10,6 @@ cue_exported_standalone_files(
     srcs = ["stamped.cue"],
     inject = {
         "builtat": "{BUILD_TIMESTAMP}",
-        "builtby": "{BUILD_USER}",
         "message": "Goodbye.",
     },
     stamping_policy = "Force",

--- a/test/testdata/stamp/stamp-golden.json
+++ b/test/testdata/stamp/stamp-golden.json
@@ -1,5 +1,5 @@
 {
     "builtAtWidth": 20,
-    "builtBy": "seh",
+    "builtBy": "unknown",
     "message": "Goodbye."
 }


### PR DESCRIPTION
Test fails when run by other users. Golden file may get formatted.