### PR TITLE
Add `-p` to cue_consolidated_files

### DIFF
--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -622,6 +622,7 @@ def _make_instance_consuming_action(ctx, cue_subcommand, mnemonic, description, 
 def _augment_consolidated_output_args(ctx, args):
     args.add("--out", ctx.attr.output_format)
     args.add("-p", ctx.attr.package_name)
+    args.add("-l", ctx.attr.expression)
 
 def _add_common_consolidated_output_attrs_to(attrs):
     attrs.update({
@@ -638,6 +639,10 @@ def _add_common_consolidated_output_attrs_to(attrs):
         ),
         "package_name": attr.string(
             doc = "Package Name for non-CUE files",
+            default = "",
+        ),
+        "expression": attr.string(
+            doc = "CUE expression for single path component",
             default = "",
         ),
         "result": attr.output(

--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -621,6 +621,7 @@ def _make_instance_consuming_action(ctx, cue_subcommand, mnemonic, description, 
 
 def _augment_consolidated_output_args(ctx, args):
     args.add("--out", ctx.attr.output_format)
+    args.add("-p", ctx.attr.package_name)
 
 def _add_common_consolidated_output_attrs_to(attrs):
     attrs.update({
@@ -634,6 +635,10 @@ def _add_common_consolidated_output_attrs_to(attrs):
                 "text",
                 "yaml",
             ],
+        ),
+        "package_name": attr.string(
+            doc = "Package Name for non-CUE files",
+            default = "",
         ),
         "result": attr.output(
             doc = """The built result in the format specified in the "output_format" attribute.""",

--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -622,7 +622,6 @@ def _make_instance_consuming_action(ctx, cue_subcommand, mnemonic, description, 
 def _augment_consolidated_output_args(ctx, args):
     args.add("--out", ctx.attr.output_format)
     args.add("-p", ctx.attr.package_name)
-    args.add("--path", ctx.attr.path_expression)
 
 def _add_common_consolidated_output_attrs_to(attrs):
     attrs.update({
@@ -639,10 +638,6 @@ def _add_common_consolidated_output_attrs_to(attrs):
         ),
         "package_name": attr.string(
             doc = "Package Name for non-CUE files",
-            default = "",
-        ),
-        "path_expression": attr.string(
-            doc = "CUE expression for single path component",
             default = "",
         ),
         "result": attr.output(

--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -622,7 +622,7 @@ def _make_instance_consuming_action(ctx, cue_subcommand, mnemonic, description, 
 def _augment_consolidated_output_args(ctx, args):
     args.add("--out", ctx.attr.output_format)
     args.add("-p", ctx.attr.package_name)
-    args.add("-l", ctx.attr.expression)
+    args.add("--path", ctx.attr.path_expression)
 
 def _add_common_consolidated_output_attrs_to(attrs):
     attrs.update({
@@ -641,7 +641,7 @@ def _add_common_consolidated_output_attrs_to(attrs):
             doc = "Package Name for non-CUE files",
             default = "",
         ),
-        "expression": attr.string(
+        "path_expression": attr.string(
             doc = "CUE expression for single path component",
             default = "",
         ),


### PR DESCRIPTION
# What

This adds `-p` to `cue def` to allow naming non-CUE files with a package name

# Testing

Test yaml
```
$ cat test/test.yaml
here: there
outer: inner
build:
  spec:
    metadata:
      labels:
        this: thing
    containers:
    - name: test
      image: thatimage
```

Test Bazel
```
$ cat test/BUILD.bazel
cue_consolidated_files(
    name = "test",
    srcs = [
        "test.yaml"
    ],
    package_name = "environmentbuild",
    module = "//cue.mod",
)
```

Building my test
```
$ bazel build //test:test
INFO: Analyzed target //test:test (25 packages loaded, 190 targets configured).
INFO: Found 1 target...
Target //test:test up-to-date:
  bazel-bin/test/test.cue
INFO: Elapsed time: 0.296s, Critical Path: 0.11s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```

```
$ cat bazel-bin/test/test.cue
package environmentbuild

here:  "there"
outer: "inner"
build: spec: {
	metadata: labels: this: "thing"
	containers: [{
		name:  "test"
		image: "thatimage"
	}]
}
```

The repo builds
```
$ bazel-5.2.0 build //...
INFO: Analyzed 46 targets (22 packages loaded, 127 targets configured).
INFO: Found 46 targets...
INFO: Elapsed time: 0.281s, Critical Path: 0.01s
INFO: 1 process: 1 internal.
INFO: Build completed successfully, 1 total action
```