### PR TITLE
Fixed value check to be the correct value from the list of permitted ones.

### DIFF
--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -33,7 +33,7 @@ CUEInstanceInfo = provider(
 
 def _replacer_if_stamping(stamping_policy):
     # NB: We can't access the "_cue_config" attribute here.
-    return Label("//tools/cmd/replace-stamps") if stamping_policy != "Never" else None
+    return Label("//tools/cmd/replace-stamps") if stamping_policy != "Prevent" else None
 
 def _add_common_source_consuming_attrs_to(attrs):
     attrs.update({


### PR DESCRIPTION
Deactivating Stamping doesn't work since the value it checks against is not in the list of permitted values for the label. 
Fixed the value that is checked against to be "Prevent" from the list. 